### PR TITLE
Add openSUSE/artwork submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = chameleon-2.0
 	url = https://github.com/openSUSE/chameleon.git
 	branch = rel-2.0
+[submodule "artwork"]
+	path = artwork
+	url = https://github.com/openSUSE/artwork.git


### PR DESCRIPTION
chameleon repo will remove all images and artwork repo is the only source-of-truth of images.